### PR TITLE
User one decoder per thread

### DIFF
--- a/src/bin/fdk-mqa-scoring-service.rs
+++ b/src/bin/fdk-mqa-scoring-service.rs
@@ -1,5 +1,8 @@
-use fdk_mqa_scoring_service::kafka::{self};
+use std::time::Duration;
+
+use fdk_mqa_scoring_service::kafka::{self, SCHEMA_REGISTRY};
 use futures::stream::{FuturesUnordered, StreamExt};
+use schema_registry_converter::async_impl::schema_registry::SrSettings;
 
 #[tokio::main]
 async fn main() {
@@ -10,8 +13,26 @@ async fn main() {
         .with_current_span(false)
         .init();
 
+    let mut schema_registry_urls = SCHEMA_REGISTRY.split(",");
+    let mut sr_settings_builder =
+        SrSettings::new_builder(schema_registry_urls.next().unwrap_or_default().to_string());
+    schema_registry_urls.for_each(|url| {
+        sr_settings_builder.add_url(url.to_string());
+    });
+
+    let sr_settings = sr_settings_builder
+        .set_timeout(Duration::from_secs(5))
+        .build()
+        .unwrap_or_else(|e| {
+            tracing::error!(
+                error = e.to_string().as_str(),
+                "unable to create SrSettings"
+            );
+            std::process::exit(1);
+        });
+
     (0..4)
-        .map(|i| tokio::spawn(kafka::run_async_processor(i)))
+        .map(|i| tokio::spawn(kafka::run_async_processor(i, sr_settings.clone())))
         .collect::<FuturesUnordered<_>>()
         .for_each(|result| async {
             result

--- a/tests/kafka_utils.rs
+++ b/tests/kafka_utils.rs
@@ -10,13 +10,17 @@ use rdkafka::{
     ClientConfig,
 };
 use schema_registry_converter::{
-    async_impl::{avro::AvroEncoder, schema_registry::SrSettings},
+    async_impl::{
+        avro::{AvroDecoder, AvroEncoder},
+        schema_registry::SrSettings,
+    },
     schema_registry_common::SubjectNameStrategy,
 };
 use serde::Serialize;
 
 pub async fn process_single_message() -> Result<(), Error> {
     let consumer = create_consumer().unwrap();
+    let mut decoder = AvroDecoder::new(sr_settings());
 
     // Attempt to receive message for 3s before aborting with an error
     let message = tokio::time::timeout(Duration::from_millis(3000), consumer.stream().next())
@@ -25,7 +29,7 @@ pub async fn process_single_message() -> Result<(), Error> {
         .unwrap()
         .unwrap();
 
-    handle_message(&message).await
+    handle_message(&mut decoder, &message).await
 }
 
 pub fn sr_settings() -> SrSettings {


### PR DESCRIPTION
Reverts https://github.com/Informasjonsforvaltning/fdk-mqa-scoring-service/pull/31 and moves creation of decoder to thread init instead of per incoming message.